### PR TITLE
Improve versioning when developing locally

### DIFF
--- a/mkosi.bump
+++ b/mkosi.bump
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ "$CI" = "true" ]
+then
+    v="$(git describe --tags --dirty | sed -e 's/^v//g')"
+    /bin/echo -n "${v:-0.0.1}"
+    exit 0
+fi
+date +%y%m%d.%H%M

--- a/mkosi.version
+++ b/mkosi.version
@@ -1,3 +1,8 @@
 #!/bin/sh
+if [ "$CI" != "true" ]
+then
+    echo "For local builds, you can delete mkosi.version, and pass -B to mkosi to" 1>&2
+    echo "have mkosi.bump generate a time-based version." 1>&2
+fi
 v="$(git describe --tags --dirty | sed -e 's/^v//g')"
 /bin/echo -n "${v:-0.0.1}"


### PR DESCRIPTION
When invoking mkosi with `-B` (/`--auto-bump`) and `mkosi.version` doesn't exist, but `mkosi.bump` does, `mkosi.bump` is called to generate a version. If the build succeeds, the version is persisted to mkosi.version.

This is very helpful when developing locally.