### PR TITLE
Consul networking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,13 +141,13 @@ jobs:
           done
 #      - name: Sign artifacts
 #        run: for file in out/mangos* ; do cosign sign-blob -d -y --bundle "${file}.sigbundle" "${file}" > /dev/null; done
-      - name: Upload asciinema cast files
-        id: upload-acast
+      - name: Upload debug logs
+        id: upload-debug-logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: acast
-          path: mangos-*.acast
+          name: debug-logs
+          path: debug_logs/*
       - name: Upload build artifact (disk)
         id: upload-disk
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,13 +110,13 @@ jobs:
           done
 #      - name: Sign artifacts
 #        run: for file in out/mangos* ; do cosign sign-blob -d -y --bundle "${file}.sigbundle" "${file}" > /dev/null; done
-      - name: Upload asciinema cast files
-        id: upload-acast
+      - name: Upload debug logs
+        id: upload-debug-logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: acast
-          path: mangos-*.acast
+          name: debug-logs
+          path: debug_logs/*
       - name: Upload build artifact (disk)
         id: upload-disk
         uses: actions/upload-artifact@v4

--- a/mkosi.images/base/mkosi.extra/usr/share/mangos/self_test.sh
+++ b/mkosi.images/base/mkosi.extra/usr/share/mangos/self_test.sh
@@ -17,6 +17,9 @@ EOF
 
 mangosctl bootstrap
 mangosctl sudo enroll -g{vault-server,{nomad,consul}-{server,client}}s 127.0.0.1
+ip addr
+ip link
+mangosctl sudo -- nomad node status -self -json
 mangosctl sudo -- nomad job run /usr/share/mangos/test.nomad
 
 env VAULT_ADDR=https://127.0.0.1:8200/ \

--- a/mkosi.images/nomad/share/nomad/nomad.hcl
+++ b/mkosi.images/nomad/share/nomad/nomad.hcl
@@ -30,6 +30,23 @@ client {
   enabled                     = true
   bridge_network_hairpin_mode = true
 
+  # During testing (in Github Actions), we're several levels deep:
+  # Azure host (wholly unavailable to us, but listed for completeness)
+  # Azure VM / Github Action runner VM (I *think* these are one and the same)
+  # Mangos test VM
+  # Container inside Mangos test VM
+  #
+  # We use ${attr.unique.network.ip-address} to the the host's IP address.
+  # This generally works, but cloud provider fingerprinting logic in Nomad
+  # overrides this with the detected cloud provider IP address, i.e. the IP
+  # address of the Azure VM.
+  #
+  # To avoid this, we disable all cloud provider fingerprinting. If we need
+  # to undo this, find a different way to determine the IP.
+  options = {
+    "fingerprint.denylist" = "env_aws,env_gce,env_azure,env_digitalocean"
+  }
+
   host_network "default" {
     cidr = "{{ GetDefaultInterfaces | exclude \"type\" \"IPv6\" | attr \"string\" }}"
   }

--- a/mkosi.images/terraform/share/terraform/consul-service.tf
+++ b/mkosi.images/terraform/share/terraform/consul-service.tf
@@ -64,8 +64,12 @@ resource "consul_config_entry_service_intentions" "consul" {
 
 resource "nomad_job" "consul" {
   jobspec = file("${path.module}/consul.nomad")
+  hcl2 {
+    vars = {
+      namespace = nomad_namespace.admin.name
+    }
+  }
   depends_on = [
-    nomad_namespace.admin,
     vault_consul_secret_backend_role.consul-api,
     vault_jwt_auth_backend_role.consul,
     consul_acl_binding_rule.consul-service,

--- a/mkosi.images/terraform/share/terraform/consul.nomad
+++ b/mkosi.images/terraform/share/terraform/consul.nomad
@@ -34,10 +34,10 @@ job "consul" {
       template {
         data = <<-EOF
         encrypt   = "{{ with secret "secrets/mangos/consul/gossip" }}{{ .Data.encryption_key | trimSpace }}{{ end }}"
-        node_name = "consul-api-{{ env "NOMAD_SHORT_ALLOC_ID" }}"
         addresses {
           dns = "0.0.0.0"
         }
+        node_name = "consul-api-{{ env "NOMAD_SHORT_ALLOC_ID" }}"
         acl {
           enabled = true
           tokens {
@@ -52,11 +52,17 @@ job "consul" {
         destination = "${NOMAD_SECRETS_DIR}/consul.hcl"
         change_mode = "restart"
       }
+
       driver = "docker"
+
+      env {
+        HOST_IP = "${attr.unique.network.ip-address}"
+      }
+
       config {
         image = "hashicorp/consul"
         args  = ["agent",
-                 "-retry-join", "10.0.2.15",
+                 "-retry-join", "${HOST_IP}",
                  "-datacenter", "${NOMAD_REGION}-${NOMAD_DC}",
                  "-config-file", "${NOMAD_SECRETS_DIR}/consul.hcl"]
       }

--- a/mkosi.images/terraform/share/terraform/variables.tf
+++ b/mkosi.images/terraform/share/terraform/variables.tf
@@ -160,11 +160,11 @@ variable "nomad-vault-max-lease-ttl" {
 variable "nomad-vault-max-ttl" {
   description = "The max TTL (in seconds) for the Vault Nomad backend"
   type        = string
-  default     = "240"
+  default     = "600"
 }
 
 variable "nomad-vault-ttl" {
   description = "The TTL (in seconds) for the Vault Nomad backend"
   type        = string
-  default     = "120"
+  default     = "240"
 }


### PR DESCRIPTION
`${attr.unique.network.ip-address}` has the host's IP. Use that for
`-retry-join` instead of assuming the user mode networking IP
(10.0.2.15).

Changing "static" to "to" for the http port means a dynamic port is
assigned and it's no longer exposed on port 8500 of the host.

Add a separate service for DNS that resolves to the host's IP.