### PR TITLE
Improve test reliability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,11 +119,13 @@ jobs:
           # Asciinema lets us record the VM text console.
           sudo apt-get install -y ovmf asciinema
       - name: Run (only) installer test with nvme block device
+        timeout-minutes: 15
         run: |
           #!/bin/bash
           ./run_tests.sh --blockdev-type nvme --no-self-test
 
       - name: Run full self test with virtio block device
+        timeout-minutes: 15
         run: |
           #!/bin/bash
           ./run_tests.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,11 +88,13 @@ jobs:
           # Asciinema lets us record the VM text console.
           sudo apt-get install -y ovmf asciinema
       - name: Run (only) installer test with nvme block device
+        timeout-minutes: 15
         run: |
           #!/bin/bash
           ./run_tests.sh --blockdev-type nvme --no-self-test
 
       - name: Run full self test with virtio block device
+        timeout-minutes: 15
         run: |
           #!/bin/bash
           ./run_tests.sh

--- a/mkosi.images/initrd/mkosi.extra/usr/lib/mangos/mangos-install
+++ b/mkosi.images/initrd/mkosi.extra/usr/lib/mangos/mangos-install
@@ -80,6 +80,8 @@ partition_device_name() {
 	esac
 }
 
+install_target="$(readlink -f "${install_target}")"
+
 ${echo} /usr/lib/systemd/systemd-pull --force --verify=no --roothash=no --verity=no --direct raw "file://${rootimg}" "$(partition_device_name "${install_target}" 5)"
 
 # Extract partition UUID and set partition name from the filename.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -88,7 +88,7 @@ then
 	usage
 fi
 
-install_target="/dev/vdb"
+install_target=/dev/disk/by-id/virtio-persistent
 
 eval set -- "${args}"
 while true
@@ -101,10 +101,10 @@ do
         --blockdev-type)
             case "$2" in
                 virtio-blk-pci)
-                    install_target=/dev/vdb
+                    install_target=/dev/disk/by-id/virtio-persistent
                     ;;
                 nvme)
-                    install_target=/dev/nvme1n1
+                    install_target=/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_persistent
                     ;;
                 *)
                     echo "Invalid block device type: $2" >&2


### PR DESCRIPTION
Cap runs of `run_tests.sh` to 15 minutes.

The order of drives is non-deterministic, so use stable symlink from `/dev/disk/by-id`.